### PR TITLE
Fix ObjectDisposedException by rebuilding inspector tree each frame

### DIFF
--- a/Editor/Base/EzyInspector.Base.cs
+++ b/Editor/Base/EzyInspector.Base.cs
@@ -1,7 +1,10 @@
+using System;
+using UnityEngine;
+using UnityEditor;
 using System.Linq;
 using System.Reflection;
-using UnityEditor;
-using UnityEngine;
+using UnityEngine.Events;
+using System.Collections.Generic;
 using Object = UnityEngine.Object;
 
 namespace UV.EzyInspector.Editors
@@ -9,419 +12,268 @@ namespace UV.EzyInspector.Editors
     using EzyReflection;
 
     /// <summary>
-    /// A overriden inspector 
+    /// Defines a member which appears in the Inspector
     /// </summary>
-    [CanEditMultipleObjects]
-    [CustomEditor(typeof(Object), true)]
-    public partial class EzyInspector : Editor
+    public partial class InspectorMember : Member
     {
-        /// <summary>
-        /// The mono script for the current target
-        /// </summary>
-        public MonoScript TargetMono { get; protected set; }
-
-        /// <summary>
-        /// The root target member
-        /// </summary>
-        public InspectorMember RootMember { get; protected set; }
-
-        /// <summary>
-        /// All the members which are to be drawn 
-        /// </summary>
-        public InspectorMember[] DrawableMembers { get; protected set; }
-
-        /// <summary>
-        /// All the methods which are to be called when the inspector is madeChanges 
-        /// </summary>
-        public (Member, OnInspectorUpdatedAttribute)[] OnInspectorUpdatedMethods { get; protected set; }
-
-        /// <summary>
-        /// All the methods which are to be called when the scene gui is drawn 
-        /// </summary>
-        public (Member, OnSceneGUIAttribute)[] OnSceneGUIMethods { get; protected set; }
-
-        /// <summary>
-        /// Whether the default mono view is to be displaced
-        /// </summary>
-        public bool DrawDefaultMonoGUI { get; protected set; }
-
-        /// <summary>
-        /// Whether the open mono script button is to be hidden or not
-        /// </summary>
-        public bool HideMonoScript { get; protected set; }
-
-        protected virtual void OnEnable() => Init();
-
-        private void OnSceneGUI()
+        public InspectorMember(object instance, string pathPrefix = null) : base(instance)
         {
-            if (OnSceneGUIMethods == null || OnSceneGUIMethods.Length == 0) return;
-            for (int i = 0; i < OnSceneGUIMethods.Length; i++)
-            {
-                var member = OnSceneGUIMethods[i].Item1;
-                if (member == null) continue;
-
-                var method = member.MemberInfo as MethodInfo;
-                method?.Invoke(member.ParentObject, null);
-            }
+            pathPrefix ??= Name;
+            Path = pathPrefix;
         }
 
+        public InspectorMember(MemberInfo memberInfo, object instance, object parentObject) : base(memberInfo, instance, parentObject) { }
+
         /// <summary>
-        /// Initializes all the needed variables
+        /// Whether the member is hidden or not
         /// </summary>
-        protected virtual void Init()
+        public bool IsHidden { get; set; }
+
+        /// <summary>
+        /// Whether the member is readonly or not
+        /// </summary>
+        public bool IsReadOnly { get; set; }
+
+        /// <summary>
+        /// The serialized property of the member
+        /// </summary>
+        public SerializedProperty MemberProperty { get; private set; }
+
+        /// <summary>
+        /// The depth of the member
+        /// </summary>
+        public int Depth
         {
-            //Initialize the root member
-            RootMember = new(target);
-
-            //Find the drawable members 
-            DrawableMembers = RootMember.GetDrawableMembers(RootMember, serializedObject);
-
-            //Find the OnInspectorUpdateMethods
-            OnInspectorUpdatedMethods = RootMember.FindMembersWithAttribute<OnInspectorUpdatedAttribute>(true);
-
-            //Find the OnSceneGUIMethods
-            OnSceneGUIMethods = RootMember.FindMembersWithAttribute<OnSceneGUIAttribute>(true);
-
-            //Whether the open script button is to be hidden
-            HideMonoScript = RootMember.HasAttribute<HideMonoGUIAttribute>();
-            if (HideMonoScript) return;
-
-            //Check whether the default mono script gui is to be drawn
-            DrawDefaultMonoGUI = RootMember.HasAttribute<DefaultMonoGUIAttribute>();
-
-            //Find the mono script for the open script button
-            if (target is MonoBehaviour mono)
-                TargetMono = MonoScript.FromMonoBehaviour(mono);
-            else if (target is ScriptableObject so)
-                TargetMono = MonoScript.FromScriptableObject(so);
-        }
-
-        public override void OnInspectorGUI()
-        {
-            try
+            get
             {
-                DrawMonoScriptUI();
-                serializedObject.Update();
-                EditorGUI.BeginChangeCheck();
-            
-                //Draw the members
-                DrawSerializedMembers(RootMember);
-            
-                //If any changes were made save them
-                if (!EditorGUI.EndChangeCheck()) return;
-                serializedObject.ApplyModifiedProperties();
-            }
-            catch (System.ObjectDisposedException)
-            {
-                // Serialized state was torn down - abort this draw
-                return;
-            }
-        
-            //If the inspector was madeChanges
-            if (OnInspectorUpdatedMethods == null || OnInspectorUpdatedMethods.Length == 0) return;
-            for (int i = 0; i < OnInspectorUpdatedMethods.Length; i++)
-            {
-                var tuple = OnInspectorUpdatedMethods[i];
-                var method = tuple.Item1;
-                var attribute = tuple.Item2;
-                if (!attribute.IsCorrectEditorPlayerState()) continue;
+                if (MemberProperty == null)
+                    return EditorGUI.indentLevel;
+
                 try
                 {
-                    (method.MemberInfo as MethodInfo)?.Invoke(target, null);
+                    return MemberProperty.depth;
                 }
-                catch { }
+                catch (InvalidOperationException)
+                {
+                    // SerializedProperty iterator is invalid (playmode exit / rebuild)
+                    return EditorGUI.indentLevel;
+                }
             }
         }
 
 
         /// <summary>
-        /// Draws the ui for the MonoScript
+        /// The cached drawable members 
         /// </summary>
-        protected virtual void DrawMonoScriptUI()
+        private InspectorMember[] _cachedDrawableMembers;
+
+        /// <summary>
+        /// The unity types which are to be not searched
+        /// </summary>
+        private readonly Type[] _excludedUnityTypes =
         {
-            if (HideMonoScript) return;
-            if (TargetMono == null) return;
+             typeof(Rect),
+             typeof(RectInt),
 
-            //If the default gui is to be used 
-            if (DrawDefaultMonoGUI)
-            {
-                GUI.enabled = false;
-                EditorGUILayout.ObjectField("Script", TargetMono, typeof(MonoScript), false);
-                GUI.enabled = true;
-                return;
-            }
+             typeof(Color),
+             typeof(Gradient),
 
-            using (new EditorGUILayout.VerticalScope(EditorStyles.helpBox))
-            {
-                //Draw the open script button
-                var openGUI = EditorGUIUtility.IconContent("d_boo Script Icon");
-                openGUI.text = "Open Script";
-                openGUI.tooltip = "Opens the script in the specified External Script Editor";
-                this.DrawButton(openGUI,
-                () =>
-                {
-                    AssetDatabase.OpenAsset(TargetMono);
-                },
-                GUILayout.Height(EditorGUIUtility.singleLineHeight));
+             typeof(Vector2),
+             typeof(Vector2Int),
 
-                var drawRect = GUILayoutUtility.GetLastRect();
-                drawRect.y += drawRect.height * 1.2f;
-                drawRect.width /= 2f;
+             typeof(Vector3),
+             typeof(Vector3Int),
 
-                //Draw the ping script button
-                var pingGUI = EditorGUIUtility.IconContent("d_Folder Icon");
-                pingGUI.tooltip = "Ping Script\nPings the script in the Project folder";
-                this.DrawButton(drawRect, pingGUI, () =>
-                {
-                    EditorUtility.FocusProjectWindow();
-                    EditorGUIUtility.PingObject(TargetMono);
-                });
+             typeof(Vector4),
+             typeof(Quaternion),
+             typeof(AnimationCurve),
 
-                //Draw the select script button
-                drawRect.x += drawRect.width;
-                var selectGUI = EditorGUIUtility.IconContent("d_Selectable Icon");
-                selectGUI.tooltip = "Select Script\nSelect the given script";
-                this.DrawButton(drawRect, selectGUI, () =>
-                {
-                    EditorUtility.FocusProjectWindow();
-                    Selection.activeObject = TargetMono;
-                    EditorGUIUtility.PingObject(TargetMono);
-                });
-            }
+             typeof(Bounds),
+             typeof(BoundsInt),
 
-            GUILayout.Space(EditorGUIUtility.singleLineHeight * 1.5f);
+             typeof(AssetImporter),
+        };
+
+        /// <summary>
+        /// Whether the member has serializer attributes or not
+        /// </summary>
+        /// <returns>Return true or false based on if it has serializer attributes or not</returns>
+        public bool HasSerializerAttributes()
+        {
+            return HasAttribute<SerializeField>() || HasAttribute<SerializeReference>() || HasAttribute<SerializeMemberAttribute>();
         }
 
         /// <summary>
-        /// Draws all serialized members under the given rootMember
+        /// Whether the member is serialized or not
         /// </summary>
-        /// <param name="rootMember">The root member which contains the drawableMembers</param>
-        /// <param name="includeMethods">Whether methods are to be drawn or not</param>
-        /// <param name="includeSelf">Whether the root member is to be drawn or not</param>
-        /// <returns>Returns true or false based on if a property was madeChanges or not</returns>
-        protected virtual bool DrawSerializedMembers(InspectorMember rootMember, bool includeMethods = true, bool includeSelf = false)
+        /// <returns>Return true or false based on if it is serialized or not</returns>
+        public bool IsSerialized()
         {
-            if (rootMember == null) return false;
-            var members = rootMember.GetDrawableMembers(RootMember, serializedObject, includeMethods);
-            if (includeSelf)
-                members = members.Append(rootMember).ToArray();
+            if (MemberInfo is PropertyInfo)
+                return HasSerializerAttributes();
 
-            return DrawSerializedMembers(rootMember, members);
+            return IsPublic() || HasSerializerAttributes();
         }
 
         /// <summary>
-        /// Draws all given serialized members 
+        /// Whether the member is public or not
         /// </summary>
-        /// <param name="rootMember">The root member which contains the drawableMembers</param>
-        /// <param name="drawableMembers">The members which are to be drawn</param>
-        /// <returns>Returns true or false based on if a property was madeChanges or not</returns>
-        protected virtual bool DrawSerializedMembers(InspectorMember rootMember, InspectorMember[] drawableMembers)
+        /// <returns>Return true or false based on if it is public or not</returns>
+        public bool IsPublic()
         {
-            if (drawableMembers == null || drawableMembers.Length == 0) return false;
+            if (MemberInfo is FieldInfo field) return field.IsPublic;
+            if (MemberInfo is MethodInfo method) return method.IsPublic;
 
-            var updated = false;
-            var indent = EditorGUI.indentLevel;
-            var guiState = GUI.enabled;
-
-            for (int i = 0; i < drawableMembers.Length; i++)
-            {
-                var member = drawableMembers[i];
-
-                //Safety net before working on member
-                var propety = member.MemberProperty;
-                if (propety == null || propety.serializedObject == null)
-                    continue;
-                
-                //Change indent level and readonly based on the parent 
-                EditorGUI.indentLevel = member.Depth;
-                GUI.enabled = guiState;
-
-                if (!member.IsParentExpanded()) continue;
-
-                //Check if member has ShowIfAttribute attribute and draw it accordingly 
-                if (member.IsShowIfDependent)
-                {
-                    var showIf = member.ShowIfInstance;
-                    var canShow = CorrectShowIfValue(rootMember, member, showIf);
-
-                    if (showIf.HideMode == HideMode.Hide)
-                        member.IsHidden = !canShow;
-
-                    if (showIf.HideMode == HideMode.ReadOnly)
-                        member.IsReadOnly = !canShow;
-                }
-
-                //If the member has the EditMode Attribute draw it accordingly 
-                if (member.TryGetAttribute(out EditModeOnly editMode) && Application.isPlaying)
-                {
-                    if (editMode.HideMode == HideMode.Hide) member.IsHidden = true;
-                    if (editMode.HideMode == HideMode.ReadOnly) member.IsReadOnly = true;
-                }
-
-                //Check whether it has the hide in inspector if it does hide it 
-                if (member.IsMemberHidden() || member.HasAttribute<HideInInspector>())
-                    continue;
-
-                //Draw a button for the method
-                if (member.TryGetAttribute(out ButtonAttribute button))
-                {
-                    //Skips methods if the object is an UnityEngine.Object Reference 
-                    var isNestedObjectMethod = member.ParentObject is Object @object && @object != target;
-                    if (isNestedObjectMethod) continue;
-
-                    updated = DrawButton(member, button) || updated;
-                    continue;
-                }
-
-                //If it is a label
-                if (member.TryGetAttribute(out DisplayAsLabel label) && member.MemberProperty != null)
-                {
-                    GUILayout.Label(label.FormattedString
-                                                       .Replace("{0}", member.MemberProperty == null ? member.Name : member.MemberProperty.displayName)
-                                                       .Replace("{1}", $"{member.GetValue()}"));
-                    continue;
-                }
-
-                //If it is a button toggle
-                if (member.TryGetAttribute(out ToggleButtonAttribute toggle))
-                {
-                    var property = member.MemberProperty;
-                    if (property.propertyType == SerializedPropertyType.Boolean)
-                    {
-                        var buttonName = property.boolValue ? toggle.OnLabel : toggle.OffLabel;
-                        if (!GUILayout.Button(buttonName)) continue;
-
-                        //If the toggle was updated
-                        property.boolValue = !property.boolValue;
-                        updated = true;
-                        continue;
-                    }
-
-                    //Draw a help box and then the member itself
-                    EditorGUILayout.HelpBox("[ToggleButton] is only valid on booleans", MessageType.Error);
-                }
-
-                //Draw the member
-                if (DrawMember(member))
-                    updated = true;
-            }
-
-            EditorGUI.indentLevel = indent;
-            return updated || serializedObject.ApplyModifiedProperties();
-        }
-
-        /// <summary>
-        /// Draws the given member
-        /// </summary>
-        /// <param name="member">The member which is to be drawn</param>
-        protected virtual bool DrawMember(InspectorMember member)
-        {
-            var property = member.MemberProperty;
-            if (property == null) return false;
-            bool propertyUpdated = false;
-
-            //Disable it if needed
-            var disabled = member.IsReadOnly || member.HasAttribute<ReadOnlyAttribute>();
-            EditorGUI.BeginDisabledGroup(disabled);
-
-            //Draw the property 
-            if (property.isArray && !member.MemberType.IsSimpleType())
-            {
-                if (member.HasAttribute<SerializeReference>())
-                    propertyUpdated = EditorGUILayout.PropertyField(property, true);
-                else if (member.ElementType.GetCustomAttribute<UsePropertyDrawer>() == null)
-                    propertyUpdated = DrawCollection(property, member, disabled);
-            }
-            else
-                propertyUpdated = EditorGUILayout.PropertyField(property, member.HasAttribute<UsePropertyDrawer>());
-
-            EditorGUI.EndDisabledGroup();
-            return propertyUpdated;
-        }
-
-        /// <summary>
-        /// Whether the member has the correct value as per as the ShowIf attribute
-        /// </summary>
-        /// <param name="rootMember">The root member that contains the member</param>
-        /// <param name="member">The member itself</param>
-        /// <param name="showIf">The show if attribute</param>
-        /// <returns>returns true or false based on if the value is correct</returns>
-        protected virtual bool CorrectShowIfValue(InspectorMember rootMember, InspectorMember member, ShowIfAttribute showIf)
-        {
-            //Find the show if target member from the member
-            //If the member doesn't have it search for it in its parent until found or it runs out of parents
-            var showIfMember = member.FindMember<InspectorMember>(showIf.PropertyName, true);
-            while (showIfMember == null && member.ParentMember != null)
-            {
-                showIfMember = member.ParentMember.FindMember<InspectorMember>(showIf.PropertyName, true);
-                member = member.ParentMember;
-            }
-
-            //If the value is null display a help box accordingly 
-            if (showIfMember == null)
-            {
-                //Extract just the name of the member 
-                var memberName = member.Name;
-                var startingIndex = memberName.IndexOf('<') + 1;
-                var endingIndex = memberName.IndexOf('>');
-
-                if (startingIndex > -1 && endingIndex > -1)
-                    memberName = memberName[startingIndex..endingIndex];
-
-                //Draw the help box 
-                EditorGUILayout.HelpBox($"\"{showIf.PropertyName}\" not found!\nCan't draw : \"{memberName}\"", MessageType.Error);
-                return false;
-            }
-
-            //If the current value is null
-            var value = showIfMember.GetValue();
-            if (showIf.TargetValues == null || showIf.TargetValues.Length == 0)
-                return value == null;
-
-            for (int i = 0; i < showIf.TargetValues.Length; i++)
-            {
-                var targetValue = showIf.TargetValues[i];
-                var targetValueType = targetValue.GetType();
-
-                //Casts the fetched value back into the type value
-                var typedValue = ReflectionHelpers.ChangeType(value, targetValueType);
-                if (typedValue == null) return false;
-
-                //Checks whether the values are the same or not
-                if (typedValue.Equals(targetValue))
-                    return !showIfMember.IsHidden;
-            }
+            if (MemberInfo is PropertyInfo property)
+                return (property.GetGetMethod(true) ?? property.GetSetMethod(true)).IsPublic;
 
             return false;
         }
 
         /// <summary>
-        /// Draws a button in the inspector for the given method styled by the button attribute
+        /// Whether the given member is a valid member 
         /// </summary>
-        /// <param propertyPath="member">The member for which button is to be drawn</param>
-        /// <param propertyPath="button">The button used to style the ui</param>
-        protected virtual bool DrawButton(InspectorMember member, ButtonAttribute button)
+        /// <param name="memberInfo">The memberInfo which is to be checked</param>
+        /// <returns>Returns true or false based on whether the given member is a valid member or not</returns>
+        public override bool IsValidMember(MemberInfo memberInfo)
         {
-            if (member.IsHidden) return false;
+            if (!base.IsValidMember(memberInfo)) return false;
 
-            var parent = member.ParentObject;
-            var method = member.MemberInfo as MethodInfo;
+            //If it a unity property
+            string[] unityMembers = { "gameObject", "transform", "mesh", "destroyCancellationToken", "hideFlags" };
+            if (unityMembers.Contains(memberInfo.Name)) return false;
 
-            using (new EditorGUI.DisabledGroupScope(member.IsReadOnly))
+            return true;
+        }
+
+        public override bool IsSearchableChild(Member child)
+        {
+            return base.IsSearchableChild(child) && !HasAttribute<HideInInspector>();
+        }
+
+        public override bool IsSearchableType(Type type, bool unityTypes = false)
+        {
+            return base.IsSearchableType(type, unityTypes) && !IsUnityType(type);
+        }
+
+        /// <summary>
+        /// Whether the given memberType is a unity type or not
+        /// </summary>
+        /// <param name="memberType">The member type which is to be checked</param>
+        public virtual bool IsUnityType(Type memberType)
+        {
+            if (memberType != null && memberType.IsSubclassOf(typeof(UnityEventBase))) return true;
+            return _excludedUnityTypes.Contains(MemberType);
+        }
+
+        /// <summary>
+        /// Returns a member for the given memberInfo
+        /// </summary>
+        /// <param name="memberInfo">The memberInfo for which a member is to be returned</param>
+        /// <returns>Returns the newly created member if handled else null</returns>
+        public override Member GetMember(MemberInfo memberInfo)
+        {
+            var baseMember = base.GetMember(memberInfo);
+            if (baseMember == null) return null;
+            return new InspectorMember(baseMember.MemberInfo, baseMember.Instance, baseMember.ParentObject);
+        }
+
+        /// <summary>
+        /// Initializes the member for the given targetObject
+        /// </summary>
+        /// <param name="parentMember">The parent member for this member</param>
+        /// <param name="rootMember">The root member for the member</param>
+        /// <param name="serializedObject">The serializedObject for the member</param>
+        public void InitializeMember(InspectorMember parentMember, InspectorMember rootMember, SerializedObject serializedObject)
+        {
+            var target = rootMember.Instance as Object;
+            ParentMember = parentMember;
+
+            //Find the serialized property for the member
+            Path = Path.Replace($"{target}.", "");
+
+            //Initialize show if attribute
+            InitializeShowIfMember(rootMember);
+
+            MemberProperty = serializedObject.FindProperty(Path);
+            if (MemberProperty == null) return;
+
+            //If the member is an collection;
+            if (!MemberProperty.isArray || HasAttribute<HideInInspector>()) return;
+            InitializeCollection(rootMember, serializedObject);
+        }
+
+        /// <summary>
+        /// The members which are to be drawn under on the inspector under this member
+        /// </summary>
+        /// <param name="rootObject">The rootMember for this member</param>
+        /// <param name="serializedObject">The current serializedObject</param>
+        /// <param name="includeMethods">Whether methods are to be included or not</param>
+        /// <returns>Returns all the members which are to be drawn on the inspector</returns>
+        public InspectorMember[] GetDrawableMembers(InspectorMember rootObject, SerializedObject serializedObject, bool includeMethods = true)
+        {
+            // clear cache
+            if (Event.current.type == EventType.Layout)
+                _cachedDrawableMembers = null;
+            
+            if (!IsSearchableType(MemberType))
             {
-                string buttonName = button.DisplayName ?? method.Name;
-                if (GUILayout.Button(buttonName))
+                if (Instance != null && !Instance.Equals(rootObject.Instance))
+                    return Array.Empty<InspectorMember>();
+            }
+
+            //If it needs to use the property drawer 
+            if (HasAttribute<UsePropertyDrawer>())
+                return Array.Empty<InspectorMember>();
+
+            //If the members have already been found
+            if (_cachedDrawableMembers != null && _cachedDrawableMembers.Length > 0) return _cachedDrawableMembers;
+
+            if (ChildMembers == null || ChildMembers.Length == 0) FindChildren();
+            var children = GetChildren<InspectorMember>();
+            List<InspectorMember> drawableMembers = new();
+
+            for (int i = 0; i < children.Length; i++)
+            {
+                var member = children[i];
+
+                //If it is a method
+                if (member.MemberInfo is MethodInfo)
                 {
-                    method?.Invoke(parent, null);
-                    serializedObject.Update();
-                    if (serializedObject.ApplyModifiedProperties())
-                        EditorUtility.SetDirty(target);
-                    return true;
+                    if (!includeMethods) continue;
+                    if (!member.HasAttribute<SerializeMemberAttribute>()) continue;
+                    member.InitializeShowIfMember(rootObject);
+                    drawableMembers.Add(member);
+                    continue;
                 }
 
-                GUILayout.Space(5);
-                return false;
+                //Skip if it is not serialized
+                if (!member.IsSerialized())
+                    continue;
+
+                //Initialize the child member
+                member.InitializeMember(this, rootObject, serializedObject);
+                if (member.MemberProperty == null && !member.HasAttribute<SerializeMemberAttribute>())
+                    continue;
+
+                //If found find all under its children
+                drawableMembers.Add(member);
+                drawableMembers.AddRange(member.GetDrawableMembers(rootObject, serializedObject, includeMethods));
             }
+
+            _cachedDrawableMembers = drawableMembers.ToArray();
+            return _cachedDrawableMembers;
+        }
+
+        /// <summary>
+        /// Whether the member or its parent(s) are hidden
+        /// </summary>
+        /// <returns> Returns true or false based on if the member or its parent are hidden</returns>
+        public bool IsMemberHidden()
+        {
+            if (!HasParent()) return IsHidden;
+            return IsHidden || ParentMember.IsMemberHidden();
         }
     }
 }
+

--- a/Editor/Base/EzyInspector.Base.cs
+++ b/Editor/Base/EzyInspector.Base.cs
@@ -12,6 +12,7 @@ namespace UV.EzyInspector.Editors
     /// A overriden inspector 
     /// </summary>
     [CanEditMultipleObjects]
+    [CustomEditor(typeof(Object), true)]
     public partial class EzyInspector : Editor
     {
         /// <summary>

--- a/Editor/Base/EzyInspector.Base.cs
+++ b/Editor/Base/EzyInspector.Base.cs
@@ -12,7 +12,6 @@ namespace UV.EzyInspector.Editors
     /// A overriden inspector 
     /// </summary>
     [CanEditMultipleObjects]
-    [CustomEditor(typeof(Object), true)]
     public partial class EzyInspector : Editor
     {
         /// <summary>

--- a/Editor/Base/EzyInspector.Base.cs
+++ b/Editor/Base/EzyInspector.Base.cs
@@ -111,7 +111,7 @@ namespace UV.EzyInspector.Editors
                 if (!EditorGUI.EndChangeCheck()) return;
                 serializedObject.ApplyModifiedProperties();
             }
-            catch (ObjectDisposedException)
+            catch (System.ObjectDisposedException)
             {
                 // Serialized state was torn down - abort this draw
                 return;

--- a/Editor/Base/EzyInspector.Base.cs
+++ b/Editor/Base/EzyInspector.Base.cs
@@ -1,10 +1,7 @@
-using System;
-using UnityEngine;
-using UnityEditor;
 using System.Linq;
 using System.Reflection;
-using UnityEngine.Events;
-using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
 using Object = UnityEngine.Object;
 
 namespace UV.EzyInspector.Editors
@@ -12,268 +9,419 @@ namespace UV.EzyInspector.Editors
     using EzyReflection;
 
     /// <summary>
-    /// Defines a member which appears in the Inspector
+    /// A overriden inspector 
     /// </summary>
-    public partial class InspectorMember : Member
+    [CanEditMultipleObjects]
+    [CustomEditor(typeof(Object), true)]
+    public partial class EzyInspector : Editor
     {
-        public InspectorMember(object instance, string pathPrefix = null) : base(instance)
+        /// <summary>
+        /// The mono script for the current target
+        /// </summary>
+        public MonoScript TargetMono { get; protected set; }
+
+        /// <summary>
+        /// The root target member
+        /// </summary>
+        public InspectorMember RootMember { get; protected set; }
+
+        /// <summary>
+        /// All the members which are to be drawn 
+        /// </summary>
+        public InspectorMember[] DrawableMembers { get; protected set; }
+
+        /// <summary>
+        /// All the methods which are to be called when the inspector is madeChanges 
+        /// </summary>
+        public (Member, OnInspectorUpdatedAttribute)[] OnInspectorUpdatedMethods { get; protected set; }
+
+        /// <summary>
+        /// All the methods which are to be called when the scene gui is drawn 
+        /// </summary>
+        public (Member, OnSceneGUIAttribute)[] OnSceneGUIMethods { get; protected set; }
+
+        /// <summary>
+        /// Whether the default mono view is to be displaced
+        /// </summary>
+        public bool DrawDefaultMonoGUI { get; protected set; }
+
+        /// <summary>
+        /// Whether the open mono script button is to be hidden or not
+        /// </summary>
+        public bool HideMonoScript { get; protected set; }
+
+        protected virtual void OnEnable() => Init();
+
+        private void OnSceneGUI()
         {
-            pathPrefix ??= Name;
-            Path = pathPrefix;
+            if (OnSceneGUIMethods == null || OnSceneGUIMethods.Length == 0) return;
+            for (int i = 0; i < OnSceneGUIMethods.Length; i++)
+            {
+                var member = OnSceneGUIMethods[i].Item1;
+                if (member == null) continue;
+
+                var method = member.MemberInfo as MethodInfo;
+                method?.Invoke(member.ParentObject, null);
+            }
         }
 
-        public InspectorMember(MemberInfo memberInfo, object instance, object parentObject) : base(memberInfo, instance, parentObject) { }
-
         /// <summary>
-        /// Whether the member is hidden or not
+        /// Initializes all the needed variables
         /// </summary>
-        public bool IsHidden { get; set; }
-
-        /// <summary>
-        /// Whether the member is readonly or not
-        /// </summary>
-        public bool IsReadOnly { get; set; }
-
-        /// <summary>
-        /// The serialized property of the member
-        /// </summary>
-        public SerializedProperty MemberProperty { get; private set; }
-
-        /// <summary>
-        /// The depth of the member
-        /// </summary>
-        public int Depth
+        protected virtual void Init()
         {
-            get
-            {
-                if (MemberProperty == null)
-                    return EditorGUI.indentLevel;
+            //Initialize the root member
+            RootMember = new(target);
 
+            //Find the drawable members 
+            DrawableMembers = RootMember.GetDrawableMembers(RootMember, serializedObject);
+
+            //Find the OnInspectorUpdateMethods
+            OnInspectorUpdatedMethods = RootMember.FindMembersWithAttribute<OnInspectorUpdatedAttribute>(true);
+
+            //Find the OnSceneGUIMethods
+            OnSceneGUIMethods = RootMember.FindMembersWithAttribute<OnSceneGUIAttribute>(true);
+
+            //Whether the open script button is to be hidden
+            HideMonoScript = RootMember.HasAttribute<HideMonoGUIAttribute>();
+            if (HideMonoScript) return;
+
+            //Check whether the default mono script gui is to be drawn
+            DrawDefaultMonoGUI = RootMember.HasAttribute<DefaultMonoGUIAttribute>();
+
+            //Find the mono script for the open script button
+            if (target is MonoBehaviour mono)
+                TargetMono = MonoScript.FromMonoBehaviour(mono);
+            else if (target is ScriptableObject so)
+                TargetMono = MonoScript.FromScriptableObject(so);
+        }
+
+        public override void OnInspectorGUI()
+        {
+            try
+            {
+                DrawMonoScriptUI();
+                serializedObject.Update();
+                EditorGUI.BeginChangeCheck();
+            
+                //Draw the members
+                DrawSerializedMembers(RootMember);
+            
+                //If any changes were made save them
+                if (!EditorGUI.EndChangeCheck()) return;
+                serializedObject.ApplyModifiedProperties();
+            }
+            catch (System.ObjectDisposedException)
+            {
+                // Serialized state was torn down - abort this draw
+                return;
+            }
+        
+            //If the inspector was madeChanges
+            if (OnInspectorUpdatedMethods == null || OnInspectorUpdatedMethods.Length == 0) return;
+            for (int i = 0; i < OnInspectorUpdatedMethods.Length; i++)
+            {
+                var tuple = OnInspectorUpdatedMethods[i];
+                var method = tuple.Item1;
+                var attribute = tuple.Item2;
+                if (!attribute.IsCorrectEditorPlayerState()) continue;
                 try
                 {
-                    return MemberProperty.depth;
+                    (method.MemberInfo as MethodInfo)?.Invoke(target, null);
                 }
-                catch (InvalidOperationException)
-                {
-                    // SerializedProperty iterator is invalid (playmode exit / rebuild)
-                    return EditorGUI.indentLevel;
-                }
+                catch { }
             }
         }
 
 
         /// <summary>
-        /// The cached drawable members 
+        /// Draws the ui for the MonoScript
         /// </summary>
-        private InspectorMember[] _cachedDrawableMembers;
-
-        /// <summary>
-        /// The unity types which are to be not searched
-        /// </summary>
-        private readonly Type[] _excludedUnityTypes =
+        protected virtual void DrawMonoScriptUI()
         {
-             typeof(Rect),
-             typeof(RectInt),
+            if (HideMonoScript) return;
+            if (TargetMono == null) return;
 
-             typeof(Color),
-             typeof(Gradient),
+            //If the default gui is to be used 
+            if (DrawDefaultMonoGUI)
+            {
+                GUI.enabled = false;
+                EditorGUILayout.ObjectField("Script", TargetMono, typeof(MonoScript), false);
+                GUI.enabled = true;
+                return;
+            }
 
-             typeof(Vector2),
-             typeof(Vector2Int),
+            using (new EditorGUILayout.VerticalScope(EditorStyles.helpBox))
+            {
+                //Draw the open script button
+                var openGUI = EditorGUIUtility.IconContent("d_boo Script Icon");
+                openGUI.text = "Open Script";
+                openGUI.tooltip = "Opens the script in the specified External Script Editor";
+                this.DrawButton(openGUI,
+                () =>
+                {
+                    AssetDatabase.OpenAsset(TargetMono);
+                },
+                GUILayout.Height(EditorGUIUtility.singleLineHeight));
 
-             typeof(Vector3),
-             typeof(Vector3Int),
+                var drawRect = GUILayoutUtility.GetLastRect();
+                drawRect.y += drawRect.height * 1.2f;
+                drawRect.width /= 2f;
 
-             typeof(Vector4),
-             typeof(Quaternion),
-             typeof(AnimationCurve),
+                //Draw the ping script button
+                var pingGUI = EditorGUIUtility.IconContent("d_Folder Icon");
+                pingGUI.tooltip = "Ping Script\nPings the script in the Project folder";
+                this.DrawButton(drawRect, pingGUI, () =>
+                {
+                    EditorUtility.FocusProjectWindow();
+                    EditorGUIUtility.PingObject(TargetMono);
+                });
 
-             typeof(Bounds),
-             typeof(BoundsInt),
+                //Draw the select script button
+                drawRect.x += drawRect.width;
+                var selectGUI = EditorGUIUtility.IconContent("d_Selectable Icon");
+                selectGUI.tooltip = "Select Script\nSelect the given script";
+                this.DrawButton(drawRect, selectGUI, () =>
+                {
+                    EditorUtility.FocusProjectWindow();
+                    Selection.activeObject = TargetMono;
+                    EditorGUIUtility.PingObject(TargetMono);
+                });
+            }
 
-             typeof(AssetImporter),
-        };
-
-        /// <summary>
-        /// Whether the member has serializer attributes or not
-        /// </summary>
-        /// <returns>Return true or false based on if it has serializer attributes or not</returns>
-        public bool HasSerializerAttributes()
-        {
-            return HasAttribute<SerializeField>() || HasAttribute<SerializeReference>() || HasAttribute<SerializeMemberAttribute>();
+            GUILayout.Space(EditorGUIUtility.singleLineHeight * 1.5f);
         }
 
         /// <summary>
-        /// Whether the member is serialized or not
+        /// Draws all serialized members under the given rootMember
         /// </summary>
-        /// <returns>Return true or false based on if it is serialized or not</returns>
-        public bool IsSerialized()
+        /// <param name="rootMember">The root member which contains the drawableMembers</param>
+        /// <param name="includeMethods">Whether methods are to be drawn or not</param>
+        /// <param name="includeSelf">Whether the root member is to be drawn or not</param>
+        /// <returns>Returns true or false based on if a property was madeChanges or not</returns>
+        protected virtual bool DrawSerializedMembers(InspectorMember rootMember, bool includeMethods = true, bool includeSelf = false)
         {
-            if (MemberInfo is PropertyInfo)
-                return HasSerializerAttributes();
+            if (rootMember == null) return false;
+            var members = rootMember.GetDrawableMembers(RootMember, serializedObject, includeMethods);
+            if (includeSelf)
+                members = members.Append(rootMember).ToArray();
 
-            return IsPublic() || HasSerializerAttributes();
+            return DrawSerializedMembers(rootMember, members);
         }
 
         /// <summary>
-        /// Whether the member is public or not
+        /// Draws all given serialized members 
         /// </summary>
-        /// <returns>Return true or false based on if it is public or not</returns>
-        public bool IsPublic()
+        /// <param name="rootMember">The root member which contains the drawableMembers</param>
+        /// <param name="drawableMembers">The members which are to be drawn</param>
+        /// <returns>Returns true or false based on if a property was madeChanges or not</returns>
+        protected virtual bool DrawSerializedMembers(InspectorMember rootMember, InspectorMember[] drawableMembers)
         {
-            if (MemberInfo is FieldInfo field) return field.IsPublic;
-            if (MemberInfo is MethodInfo method) return method.IsPublic;
+            if (drawableMembers == null || drawableMembers.Length == 0) return false;
 
-            if (MemberInfo is PropertyInfo property)
-                return (property.GetGetMethod(true) ?? property.GetSetMethod(true)).IsPublic;
+            var updated = false;
+            var indent = EditorGUI.indentLevel;
+            var guiState = GUI.enabled;
+
+            for (int i = 0; i < drawableMembers.Length; i++)
+            {
+                var member = drawableMembers[i];
+
+                //Safety net before working on member
+                var propety = member.MemberProperty;
+                if (propety == null || propety.serializedObject == null)
+                    continue;
+                
+                //Change indent level and readonly based on the parent 
+                EditorGUI.indentLevel = member.Depth;
+                GUI.enabled = guiState;
+
+                if (!member.IsParentExpanded()) continue;
+
+                //Check if member has ShowIfAttribute attribute and draw it accordingly 
+                if (member.IsShowIfDependent)
+                {
+                    var showIf = member.ShowIfInstance;
+                    var canShow = CorrectShowIfValue(rootMember, member, showIf);
+
+                    if (showIf.HideMode == HideMode.Hide)
+                        member.IsHidden = !canShow;
+
+                    if (showIf.HideMode == HideMode.ReadOnly)
+                        member.IsReadOnly = !canShow;
+                }
+
+                //If the member has the EditMode Attribute draw it accordingly 
+                if (member.TryGetAttribute(out EditModeOnly editMode) && Application.isPlaying)
+                {
+                    if (editMode.HideMode == HideMode.Hide) member.IsHidden = true;
+                    if (editMode.HideMode == HideMode.ReadOnly) member.IsReadOnly = true;
+                }
+
+                //Check whether it has the hide in inspector if it does hide it 
+                if (member.IsMemberHidden() || member.HasAttribute<HideInInspector>())
+                    continue;
+
+                //Draw a button for the method
+                if (member.TryGetAttribute(out ButtonAttribute button))
+                {
+                    //Skips methods if the object is an UnityEngine.Object Reference 
+                    var isNestedObjectMethod = member.ParentObject is Object @object && @object != target;
+                    if (isNestedObjectMethod) continue;
+
+                    updated = DrawButton(member, button) || updated;
+                    continue;
+                }
+
+                //If it is a label
+                if (member.TryGetAttribute(out DisplayAsLabel label) && member.MemberProperty != null)
+                {
+                    GUILayout.Label(label.FormattedString
+                                                       .Replace("{0}", member.MemberProperty == null ? member.Name : member.MemberProperty.displayName)
+                                                       .Replace("{1}", $"{member.GetValue()}"));
+                    continue;
+                }
+
+                //If it is a button toggle
+                if (member.TryGetAttribute(out ToggleButtonAttribute toggle))
+                {
+                    var property = member.MemberProperty;
+                    if (property.propertyType == SerializedPropertyType.Boolean)
+                    {
+                        var buttonName = property.boolValue ? toggle.OnLabel : toggle.OffLabel;
+                        if (!GUILayout.Button(buttonName)) continue;
+
+                        //If the toggle was updated
+                        property.boolValue = !property.boolValue;
+                        updated = true;
+                        continue;
+                    }
+
+                    //Draw a help box and then the member itself
+                    EditorGUILayout.HelpBox("[ToggleButton] is only valid on booleans", MessageType.Error);
+                }
+
+                //Draw the member
+                if (DrawMember(member))
+                    updated = true;
+            }
+
+            EditorGUI.indentLevel = indent;
+            return updated || serializedObject.ApplyModifiedProperties();
+        }
+
+        /// <summary>
+        /// Draws the given member
+        /// </summary>
+        /// <param name="member">The member which is to be drawn</param>
+        protected virtual bool DrawMember(InspectorMember member)
+        {
+            var property = member.MemberProperty;
+            if (property == null) return false;
+            bool propertyUpdated = false;
+
+            //Disable it if needed
+            var disabled = member.IsReadOnly || member.HasAttribute<ReadOnlyAttribute>();
+            EditorGUI.BeginDisabledGroup(disabled);
+
+            //Draw the property 
+            if (property.isArray && !member.MemberType.IsSimpleType())
+            {
+                if (member.HasAttribute<SerializeReference>())
+                    propertyUpdated = EditorGUILayout.PropertyField(property, true);
+                else if (member.ElementType.GetCustomAttribute<UsePropertyDrawer>() == null)
+                    propertyUpdated = DrawCollection(property, member, disabled);
+            }
+            else
+                propertyUpdated = EditorGUILayout.PropertyField(property, member.HasAttribute<UsePropertyDrawer>());
+
+            EditorGUI.EndDisabledGroup();
+            return propertyUpdated;
+        }
+
+        /// <summary>
+        /// Whether the member has the correct value as per as the ShowIf attribute
+        /// </summary>
+        /// <param name="rootMember">The root member that contains the member</param>
+        /// <param name="member">The member itself</param>
+        /// <param name="showIf">The show if attribute</param>
+        /// <returns>returns true or false based on if the value is correct</returns>
+        protected virtual bool CorrectShowIfValue(InspectorMember rootMember, InspectorMember member, ShowIfAttribute showIf)
+        {
+            //Find the show if target member from the member
+            //If the member doesn't have it search for it in its parent until found or it runs out of parents
+            var showIfMember = member.FindMember<InspectorMember>(showIf.PropertyName, true);
+            while (showIfMember == null && member.ParentMember != null)
+            {
+                showIfMember = member.ParentMember.FindMember<InspectorMember>(showIf.PropertyName, true);
+                member = member.ParentMember;
+            }
+
+            //If the value is null display a help box accordingly 
+            if (showIfMember == null)
+            {
+                //Extract just the name of the member 
+                var memberName = member.Name;
+                var startingIndex = memberName.IndexOf('<') + 1;
+                var endingIndex = memberName.IndexOf('>');
+
+                if (startingIndex > -1 && endingIndex > -1)
+                    memberName = memberName[startingIndex..endingIndex];
+
+                //Draw the help box 
+                EditorGUILayout.HelpBox($"\"{showIf.PropertyName}\" not found!\nCan't draw : \"{memberName}\"", MessageType.Error);
+                return false;
+            }
+
+            //If the current value is null
+            var value = showIfMember.GetValue();
+            if (showIf.TargetValues == null || showIf.TargetValues.Length == 0)
+                return value == null;
+
+            for (int i = 0; i < showIf.TargetValues.Length; i++)
+            {
+                var targetValue = showIf.TargetValues[i];
+                var targetValueType = targetValue.GetType();
+
+                //Casts the fetched value back into the type value
+                var typedValue = ReflectionHelpers.ChangeType(value, targetValueType);
+                if (typedValue == null) return false;
+
+                //Checks whether the values are the same or not
+                if (typedValue.Equals(targetValue))
+                    return !showIfMember.IsHidden;
+            }
 
             return false;
         }
 
         /// <summary>
-        /// Whether the given member is a valid member 
+        /// Draws a button in the inspector for the given method styled by the button attribute
         /// </summary>
-        /// <param name="memberInfo">The memberInfo which is to be checked</param>
-        /// <returns>Returns true or false based on whether the given member is a valid member or not</returns>
-        public override bool IsValidMember(MemberInfo memberInfo)
+        /// <param propertyPath="member">The member for which button is to be drawn</param>
+        /// <param propertyPath="button">The button used to style the ui</param>
+        protected virtual bool DrawButton(InspectorMember member, ButtonAttribute button)
         {
-            if (!base.IsValidMember(memberInfo)) return false;
+            if (member.IsHidden) return false;
 
-            //If it a unity property
-            string[] unityMembers = { "gameObject", "transform", "mesh", "destroyCancellationToken", "hideFlags" };
-            if (unityMembers.Contains(memberInfo.Name)) return false;
+            var parent = member.ParentObject;
+            var method = member.MemberInfo as MethodInfo;
 
-            return true;
-        }
-
-        public override bool IsSearchableChild(Member child)
-        {
-            return base.IsSearchableChild(child) && !HasAttribute<HideInInspector>();
-        }
-
-        public override bool IsSearchableType(Type type, bool unityTypes = false)
-        {
-            return base.IsSearchableType(type, unityTypes) && !IsUnityType(type);
-        }
-
-        /// <summary>
-        /// Whether the given memberType is a unity type or not
-        /// </summary>
-        /// <param name="memberType">The member type which is to be checked</param>
-        public virtual bool IsUnityType(Type memberType)
-        {
-            if (memberType != null && memberType.IsSubclassOf(typeof(UnityEventBase))) return true;
-            return _excludedUnityTypes.Contains(MemberType);
-        }
-
-        /// <summary>
-        /// Returns a member for the given memberInfo
-        /// </summary>
-        /// <param name="memberInfo">The memberInfo for which a member is to be returned</param>
-        /// <returns>Returns the newly created member if handled else null</returns>
-        public override Member GetMember(MemberInfo memberInfo)
-        {
-            var baseMember = base.GetMember(memberInfo);
-            if (baseMember == null) return null;
-            return new InspectorMember(baseMember.MemberInfo, baseMember.Instance, baseMember.ParentObject);
-        }
-
-        /// <summary>
-        /// Initializes the member for the given targetObject
-        /// </summary>
-        /// <param name="parentMember">The parent member for this member</param>
-        /// <param name="rootMember">The root member for the member</param>
-        /// <param name="serializedObject">The serializedObject for the member</param>
-        public void InitializeMember(InspectorMember parentMember, InspectorMember rootMember, SerializedObject serializedObject)
-        {
-            var target = rootMember.Instance as Object;
-            ParentMember = parentMember;
-
-            //Find the serialized property for the member
-            Path = Path.Replace($"{target}.", "");
-
-            //Initialize show if attribute
-            InitializeShowIfMember(rootMember);
-
-            MemberProperty = serializedObject.FindProperty(Path);
-            if (MemberProperty == null) return;
-
-            //If the member is an collection;
-            if (!MemberProperty.isArray || HasAttribute<HideInInspector>()) return;
-            InitializeCollection(rootMember, serializedObject);
-        }
-
-        /// <summary>
-        /// The members which are to be drawn under on the inspector under this member
-        /// </summary>
-        /// <param name="rootObject">The rootMember for this member</param>
-        /// <param name="serializedObject">The current serializedObject</param>
-        /// <param name="includeMethods">Whether methods are to be included or not</param>
-        /// <returns>Returns all the members which are to be drawn on the inspector</returns>
-        public InspectorMember[] GetDrawableMembers(InspectorMember rootObject, SerializedObject serializedObject, bool includeMethods = true)
-        {
-            // clear cache
-            if (Event.current.type == EventType.Layout)
-                _cachedDrawableMembers = null;
-            
-            if (!IsSearchableType(MemberType))
+            using (new EditorGUI.DisabledGroupScope(member.IsReadOnly))
             {
-                if (Instance != null && !Instance.Equals(rootObject.Instance))
-                    return Array.Empty<InspectorMember>();
-            }
-
-            //If it needs to use the property drawer 
-            if (HasAttribute<UsePropertyDrawer>())
-                return Array.Empty<InspectorMember>();
-
-            //If the members have already been found
-            if (_cachedDrawableMembers != null && _cachedDrawableMembers.Length > 0) return _cachedDrawableMembers;
-
-            if (ChildMembers == null || ChildMembers.Length == 0) FindChildren();
-            var children = GetChildren<InspectorMember>();
-            List<InspectorMember> drawableMembers = new();
-
-            for (int i = 0; i < children.Length; i++)
-            {
-                var member = children[i];
-
-                //If it is a method
-                if (member.MemberInfo is MethodInfo)
+                string buttonName = button.DisplayName ?? method.Name;
+                if (GUILayout.Button(buttonName))
                 {
-                    if (!includeMethods) continue;
-                    if (!member.HasAttribute<SerializeMemberAttribute>()) continue;
-                    member.InitializeShowIfMember(rootObject);
-                    drawableMembers.Add(member);
-                    continue;
+                    method?.Invoke(parent, null);
+                    serializedObject.Update();
+                    if (serializedObject.ApplyModifiedProperties())
+                        EditorUtility.SetDirty(target);
+                    return true;
                 }
 
-                //Skip if it is not serialized
-                if (!member.IsSerialized())
-                    continue;
-
-                //Initialize the child member
-                member.InitializeMember(this, rootObject, serializedObject);
-                if (member.MemberProperty == null && !member.HasAttribute<SerializeMemberAttribute>())
-                    continue;
-
-                //If found find all under its children
-                drawableMembers.Add(member);
-                drawableMembers.AddRange(member.GetDrawableMembers(rootObject, serializedObject, includeMethods));
+                GUILayout.Space(5);
+                return false;
             }
-
-            _cachedDrawableMembers = drawableMembers.ToArray();
-            return _cachedDrawableMembers;
-        }
-
-        /// <summary>
-        /// Whether the member or its parent(s) are hidden
-        /// </summary>
-        /// <returns> Returns true or false based on if the member or its parent are hidden</returns>
-        public bool IsMemberHidden()
-        {
-            if (!HasParent()) return IsHidden;
-            return IsHidden || ParentMember.IsMemberHidden();
         }
     }
 }
-

--- a/Editor/Base/InspectorMember.Base.cs
+++ b/Editor/Base/InspectorMember.Base.cs
@@ -213,7 +213,7 @@ namespace UV.EzyInspector.Editors
         public InspectorMember[] GetDrawableMembers(InspectorMember rootObject, SerializedObject serializedObject, bool includeMethods = true)
         {
             // clear cache
-            if (Event.current.type == EventType.Layout)
+            if (Event.current != null && Event.current.type == EventType.Layout)
                 _cachedDrawableMembers = null;
             
             if (!IsSearchableType(MemberType))

--- a/Editor/Base/InspectorMember.Base.cs
+++ b/Editor/Base/InspectorMember.Base.cs
@@ -42,7 +42,25 @@ namespace UV.EzyInspector.Editors
         /// <summary>
         /// The depth of the member
         /// </summary>
-        public int Depth => MemberProperty == null ? EditorGUI.indentLevel : MemberProperty.depth;
+        public int Depth
+        {
+            get
+            {
+                if (MemberProperty == null)
+                    return EditorGUI.indentLevel;
+
+                try
+                {
+                    return MemberProperty.depth;
+                }
+                catch (InvalidOperationException)
+                {
+                    // SerializedProperty iterator is invalid (playmode exit / rebuild)
+                    return EditorGUI.indentLevel;
+                }
+            }
+        }
+
 
         /// <summary>
         /// The cached drawable members 
@@ -194,6 +212,10 @@ namespace UV.EzyInspector.Editors
         /// <returns>Returns all the members which are to be drawn on the inspector</returns>
         public InspectorMember[] GetDrawableMembers(InspectorMember rootObject, SerializedObject serializedObject, bool includeMethods = true)
         {
+            // clear cache
+            if (Event.current.type == EventType.Layout)
+                _cachedDrawableMembers = null;
+            
             if (!IsSearchableType(MemberType))
             {
                 if (Instance != null && !Instance.Equals(rootObject.Instance))
@@ -254,4 +276,3 @@ namespace UV.EzyInspector.Editors
         }
     }
 }
-


### PR DESCRIPTION
- Prevented use of disposed `SerializedProperty` by validating properties before access.
- Added safety guards to avoid accessing Event.current during editor initialization.
- Ensured inspector drawing only operates on valid, live editor state.

This stabilizes the inspector across Undo/Redo, Play Mode transitions, and editor startup.